### PR TITLE
fix: removed .env from production

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-REACT_APP_BASE_URL="https://recruitment-api-production.up.railway.app"


### PR DESCRIPTION
accidentally left the .env file in production push it only contained a url to the api so no big deal, i hope. I have removed it though.